### PR TITLE
Add json minify

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,8 +3,10 @@
 	Author Tobias Koppers @sokra
 */
 module.exports = function(source) {
+        JSON.minify = require("node-json-minify");
+
 	this.cacheable && this.cacheable();
-	var value = typeof source === "string" ? JSON.parse(source) : source;
+	var value = typeof source === "string" ? JSON.parse(JSON.minify(source)) : source;
 	this.value = [value];
 	return "module.exports = " + JSON.stringify(value, undefined, "\t") + ";";
 }

--- a/package.json
+++ b/package.json
@@ -7,5 +7,8 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/webpack/json-loader.git"
+  },
+  "dependencies": {
+    "node-json-minify": "^1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "type": "git",
     "url": "https://github.com/webpack/json-loader.git"
   },
-  "dependencies": {
+  "devDependencies": {
     "node-json-minify": "^1.0.0"
   }
 }


### PR DESCRIPTION
I think it would be convinient to use [json.minify](https://github.com/getify/JSON.minify/tree/node) to enable and then remove the comments before parsing in json files.

I know comments are not allowed in json, but they are convinient for letting others/your future you, know whats going on without digging in source too much... especially in config files.

> Suppose you are using JSON to keep configuration files, which you would like to annotate. Go ahead and insert all the comments you like. Then pipe it through JSMin before handing it to your JSON parser. - Douglas Crockford, 2012
