### PR TITLE
ES2015 Modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,13 @@
 
 ## Installation
 
+For webpack v2 users:
+
 `npm install --save json-loader`
+
+For webpack v1 users:
+
+`npm install --save json-loader@0.5.4`
 
 ## Usage
 

--- a/index.js
+++ b/index.js
@@ -6,5 +6,5 @@ module.exports = function(source) {
 	this.cacheable && this.cacheable();
 	var value = typeof source === "string" ? JSON.parse(source) : source;
 	this.value = [value];
-	return "module.exports = " + JSON.stringify(value) + ";";
+	return "export default " + JSON.stringify(value) + ";";
 }


### PR DESCRIPTION
Since webpack v2, it's better to use ES modules. Note that this is incompatible with webpack v1, so it should be released as a major version.

Fixes #15.