### PR TITLE
Fix Maintainer section look

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,12 +68,12 @@ import json from 'json-loader!file.json';
   <tbody>
     <tr>
       <td align="center">
-        <img width="150 height="150" src="https://github.com/sokra.png?s=150">
-        <br>
+        <img width="150" height="150" src="https://avatars.githubusercontent.com/sokra?v=3">
+        </br>
         <a href="https://github.com/sokra">Tobias Koppers</a>
       </td>
-    <tr>
-  <tbody>
+    </tr>
+  </tbody>
 </table>
 
 [npm]: https://img.shields.io/npm/v/json-loader.svg


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Fix Maintainer section HTML

**Did you add tests for your changes?**
No

**If relevant, did you update the README?**
Yes

**Summary**

Maintainers section HTML was incorrect, making the website look like this:
![image](https://cloud.githubusercontent.com/assets/1002461/22202787/cafd6206-e137-11e6-9e4f-21166d51df4c.png)


After the change it looks like this:
![image](https://cloud.githubusercontent.com/assets/1002461/22202791/ce4112c8-e137-11e6-905b-b8ff1af2acc2.png)


