### PR TITLE
docs(README): add warning about webpack 2 usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,15 +13,13 @@
   <h1>JSON Loader</h1>
 </div>
 
-<h2 align="center">Note</h2>
-
-**Since webpack v2, JSON files will work by default. You might still want to use this if you use a custom file extension.**
-
 <h2 align="center">Install</h2>
 
 ```bash
 npm install --save-dev json-loader
 ```
+
+⚠️ **Note: Since webpack v2, importing of JSON files will work by default. You might still want to use this if you use a custom file extension.** 
 
 <h2 align="center">Usage</h2>
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@
   <h1>JSON Loader</h1>
 </div>
 
-**Note: Since webpack v2, JSON files will work by default. You might still want to use this if you use a custom file extension.**
+<h2 align="center">Note</h2>
+
+**Since webpack v2, JSON files will work by default. You might still want to use this if you use a custom file extension.**
 
 <h2 align="center">Install</h2>
 


### PR DESCRIPTION
Currently the note, that this loader's functionality is on by default in Webpack 2, is not visible in the [documentation page](https://webpack.js.org/loaders/json-loader/#components/sidebar/sidebar.jsx).

Moved it under its own section, hoping it'll now be visible.