### PR TITLE
revert: add `stringify` option to output JSON object as string (#43)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,17 +60,6 @@ import json from 'file.json';
 import json from 'json-loader!file.json';
 ```
 
-
-
-### Options
-
-#### `stringify`
-
-By default, the json-loader will output the json object, set this query parameter to 'true' can output the json object as a string, e.g. `require('json-loader?stringify!../index.json')`.
-
-
-
-
 <h2 align="center">Maintainer</h2>
 
 <table>
@@ -108,7 +97,6 @@ By default, the json-loader will output the json object, set this query paramete
     </tr>
   <tbody>
 </table>
-
 
 [npm]: https://img.shields.io/npm/v/json-loader.svg
 [npm-url]: https://npmjs.com/package/json-loader

--- a/index.js
+++ b/index.js
@@ -1,14 +1,10 @@
 /*
-  MIT License http://www.opensource.org/licenses/mit-license.php
-  Author Tobias Koppers @sokra
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra
 */
-var loaderUtils = require('loader-utils');
-
 module.exports = function(source) {
-    var value = typeof source === "string" ? JSON.parse(source) : source;
-    var options = loaderUtils.getOptions(this) || {};
-    value = JSON.stringify(value)
-    value = options.stringify ? `'${value}'` : value
-    var module = this.version && this.version >= 2 ? `export default ${value};` : `module.exports = ${value};`;
-    return module
+	this.cacheable && this.cacheable();
+	var value = typeof source === "string" ? JSON.parse(source) : source;
+	this.value = [value];
+	return "module.exports = " + JSON.stringify(value) + ";";
 }

--- a/package.json
+++ b/package.json
@@ -7,8 +7,5 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/webpack/json-loader.git"
-  },
-  "dependencies": {
-    "loader-utils": "^1.0.3"
   }
 }


### PR DESCRIPTION
Reverts webpack-contrib/json-loader#45

This feature is super weird. Just use the raw-loader if you want a string. The PR also introduce incorrect spacing.