### PR TITLE
fix(index): only export CJS modules (`webpack v1.0.0`) && add deprecation warning (`webpack v2.0.0`)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,12 +1,19 @@
-/*
-	MIT License http://www.opensource.org/licenses/mit-license.php
-	Author Tobias Koppers @sokra
-*/
-module.exports = function(source) {
-	var value = typeof source === "string" ? JSON.parse(source) : source;
-	value = JSON.stringify(value)
-		.replace(/\u2028/g, '\\u2028')
-		.replace(/\u2029/g, '\\u2029');
-	var module = this.version && this.version >= 2 ? `export default ${value};` : `module.exports = ${value};`;
-	return module;
+module.exports = function (source) {
+  if (this.cacheable) this.cacheable();
+
+  var value = typeof source === "string" ? JSON.parse(source) : source;
+
+  value = JSON.stringify(value)
+    .replace(/\u2028/g, '\\u2028')
+    .replace(/\u2029/g, '\\u2029');
+
+  if (this.version && this.version >= 2) {
+    this.emitWarning(`⚠️  JSON Loader\n
+It seems you're using webpack >= v2.0.0, which includes native support for JSON.
+Please remove this loader from webpack.config.js as it isn't needed anymore and
+is deprecated. See the v1.0.0 -> v2.0.0 migration guide for more information
+(https://webpack.js.org/guides/migrating/#json-loader-is-not-required-anymore)\n`)
+  }
+
+  return `module.exports = ${value}`;
 }


### PR DESCRIPTION
Closes #53  
Closes #54  