### PR TITLE
fix: Strip deprecation warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,13 +7,5 @@ module.exports = function (source) {
     .replace(/\u2028/g, '\\u2028')
     .replace(/\u2029/g, '\\u2029');
 
-  if (this.version && this.version >= 2) {
-    this.emitWarning(`⚠️  JSON Loader\n
-It seems you're using webpack >= v2.0.0, which includes native support for JSON.
-Please remove this loader from webpack.config.js as it isn't needed anymore and
-is deprecated. See the v1.0.0 -> v2.0.0 migration guide for more information
-(https://webpack.js.org/guides/migrating/#json-loader-is-not-required-anymore)\n`)
-  }
-
   return `module.exports = ${value}`;
 }


### PR DESCRIPTION
- Given the circular nature of all this, I am limiting the `should use` to documentation only.

This is a problem that has to be fixed upstream as this should be deprecated but realistically can't until webpack stops delegating to json-loader.

Closes #57